### PR TITLE
Rebrand from eoscr to edenia for github org transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
 <div align="center">
-	<a href="https://eoscostarica.io">
-		<img src="https://raw.githubusercontent.com/eoscostarica/.github/master/.github/workflows/images/eos-costa-rica-logo.png" width="300">
+	<a href="https://edenia.com">
+		<img src="https://raw.githubusercontent.com/edenia/.github/master/.github/workflows/images/edenia-logo.png" width="300" alt="Edenia Logo">
 	</a>
 
-![](https://img.shields.io/github/license/eoscostarica/eden-distribute) ![](https://img.shields.io/badge/code%20style-standard-brightgreen.svg) ![](https://img.shields.io/badge/%E2%9C%93-collaborative_etiquette-brightgreen.svg) [![](https://img.shields.io/twitter/follow/eoscostarica?style=social)](https://twitter.com/EOSCostaRica) ![](https://img.shields.io/github/forks/eoscostarica/eden-distribute?style=social)
+![](https://img.shields.io/github/license/edenia/eden-distribute) 
+![](https://img.shields.io/badge/code%20style-standard-brightgreen.svg) 
+![](https://img.shields.io/badge/%E2%9C%93-collaborative_etiquette-brightgreen.svg) 
+![](https://img.shields.io/twitter/follow/edeniaWeb3.svg?style=social&logo=twitter) 
+![](https://img.shields.io/github/forks/edenia/eden-distribute?style=social)
 
 </div>
+
 
 # Eden Delegates Funds Distribution
 
@@ -27,7 +32,7 @@ Some things you need before getting started:
 
 ### Running for the first time
 
-1.  Clone this repo using `git clone --depth=1 https://github.com/eoscostarica/eden-distribute.git <YOUR_PROJECT_NAME>`
+1.  Clone this repo using `git clone --depth=1 https://github.com/edenia/eden-distribute.git <YOUR_PROJECT_NAME>`
 2.  Move to the appropriate directory: `cd <YOUR_PROJECT_NAME>`.
 3.  Copy and rename the `.env.example` to `.env` then update the environment variables according to your needs
 
@@ -58,17 +63,21 @@ eden-distribute/
 
 Please Read EOS Costa Rica's [Open Source Contributing Guidelines](https://developers.eoscostarica.io/docs/open-source-guidelines).
 
-Please report bugs big and small by [opening an issue](https://github.com/eoscostarica/eden-distribute/issues)
+Please report bugs big and small by [opening an issue](https://github.com/edenia/eden-distribute/issues)
 
-## About EOS Costa Rica
+## About Edenia
 
-<span align="center">
+<div align="center">
 
-<a href="https://eoscostarica.io"><img width="300" alt="image" src="https://raw.githubusercontent.com/eoscostarica/.github/master/.github/workflows/images/eos-costa-rica-logo.png"></img></a>
+<a href="https://edenia.com">
+	<img width="300" alt="Edenia Logo" src="https://raw.githubusercontent.com/edenia/.github/master/.github/workflows/images/edenia-logo.png"></img>
+</a>
 
-[![Twitter](https://img.shields.io/twitter/follow/EOSCostaRica?style=for-the-badge)](https://twitter.com/EdeniaWeb3)
+[![Twitter](https://img.shields.io/twitter/follow/EdeniaWeb3?style=for-the-badge)](https://twitter.com/EdeniaWeb3)
 [![Discord](https://img.shields.io/discord/946500573677625344?color=black&label=Discord&logo=discord&logoColor=white&style=for-the-badge)](https://discord.gg/YeGcF6QwhP)
 
-EOS Costa Rica is an independently-owned, self-funded, bare-metal Genesis block producer that provides stable and secure infrastructure for the EOS mainnet. We support open source software for our community while offering enterprise solutions and custom smart contract development for our clients.
+</div>
 
-</span>
+Edenia runs independent blockchain infrastructure and develops web3 solutions. Our team of technology-agnostic builders has been operating since 1987, leveraging the newest technologies to make the internet safer, more efficient, and more transparent.
+
+[edenia.com](https://edenia.com/)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "edendistribute",
   "version": "1.0.0",
   "description": "Eden Delegates Funds Distribution Script",
-  "repository": "https://github.com/eoscostarica/eden-distribute.git",
+  "repository": "https://github.com/edenia/eden-distribute.git",
   "license": "MIT",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
Rebrand in order to prepare repo for transfer to edenia github org.